### PR TITLE
Additional playing with IronPython calls to execute Python scripts

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "conventionalCommits.scopes": [
         "dotnet",
-        "settings"
+        "settings",
+        "style"
     ]
 }

--- a/IronPythonIntro/HelloWorld/HelloWorld.csproj
+++ b/IronPythonIntro/HelloWorld/HelloWorld.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="IronPython" Version="3.4.0" />
+    <PackageReference Include="IronPython.StdLib" Version="3.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/IronPythonIntro/HelloWorld/HelloWorld.csproj
+++ b/IronPythonIntro/HelloWorld/HelloWorld.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <None Update="PythonScripts\scriptFile.py">
+    <None Update="PythonScripts\*.py">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
   </ItemGroup>

--- a/IronPythonIntro/HelloWorld/Program.cs
+++ b/IronPythonIntro/HelloWorld/Program.cs
@@ -11,7 +11,11 @@
 #endif
 
 #if !SERIALIZATION3
-#define SERIALIZATION3
+//#define SERIALIZATION3
+#endif
+
+#if !SERIALIZATION4
+#define SERIALIZATION4
 #endif
 
 namespace HelloWorld;
@@ -43,6 +47,10 @@ internal static class Program
 
 #if SERIALIZATION3
         Serialization3.Run();
+#endif
+
+#if SERIALIZATION4
+        Serialization4.Run();
 #endif
     }
 }

--- a/IronPythonIntro/HelloWorld/Program.cs
+++ b/IronPythonIntro/HelloWorld/Program.cs
@@ -1,4 +1,10 @@
-﻿using System.Reflection;
+﻿#if !ORIGINALAPP
+//#define ORIGINALAPP
+#endif
+
+#if !SERIALIZATION1
+#define SERIALIZATION1
+#endif
 
 namespace HelloWorld;
 
@@ -6,6 +12,7 @@ internal class Program
 {
     static void Main(string[] args)
     {
+#if ORIGINALAPP
         var basePath = Directory.GetParent(AppDomain.CurrentDomain.BaseDirectory);
         var scriptFilePath = Path.Combine(basePath.FullName, "PythonScripts", "scriptFile.py");
 
@@ -16,5 +23,10 @@ internal class Program
         eng.Execute(scriptContent, scope);
         dynamic greetings = scope.GetVariable("greetings");
         System.Console.WriteLine(greetings("world of Iron Python"));
+#endif
+
+#if SERIALIZATION1
+        Serialization1.Run();
+#endif
     }
 }

--- a/IronPythonIntro/HelloWorld/Program.cs
+++ b/IronPythonIntro/HelloWorld/Program.cs
@@ -3,7 +3,11 @@
 #endif
 
 #if !SERIALIZATION1
-#define SERIALIZATION1
+//#define SERIALIZATION1
+#endif
+
+#if !SERIALIZATION2
+#define SERIALIZATION2
 #endif
 
 namespace HelloWorld;
@@ -27,6 +31,10 @@ internal static class Program
 
 #if SERIALIZATION1
         Serialization1.Run();
+#endif
+
+#if SERIALIZATION2
+        Serialization2.Run();
 #endif
     }
 }

--- a/IronPythonIntro/HelloWorld/Program.cs
+++ b/IronPythonIntro/HelloWorld/Program.cs
@@ -19,7 +19,11 @@
 #endif
 
 #if !SERIALIZATION5
-#define SERIALIZATION5
+//#define SERIALIZATION5
+#endif
+
+#if !SERIALIZATION6
+#define SERIALIZATION6
 #endif
 
 namespace HelloWorld;
@@ -59,6 +63,10 @@ internal static class Program
 
 #if SERIALIZATION5
         Serialization5.Run();
+#endif
+
+#if SERIALIZATION6
+        Serialization6.Run();
 #endif
     }
 }

--- a/IronPythonIntro/HelloWorld/Program.cs
+++ b/IronPythonIntro/HelloWorld/Program.cs
@@ -7,7 +7,11 @@
 #endif
 
 #if !SERIALIZATION2
-#define SERIALIZATION2
+//#define SERIALIZATION2
+#endif
+
+#if !SERIALIZATION3
+#define SERIALIZATION3
 #endif
 
 namespace HelloWorld;
@@ -35,6 +39,10 @@ internal static class Program
 
 #if SERIALIZATION2
         Serialization2.Run();
+#endif
+
+#if SERIALIZATION3
+        Serialization3.Run();
 #endif
     }
 }

--- a/IronPythonIntro/HelloWorld/Program.cs
+++ b/IronPythonIntro/HelloWorld/Program.cs
@@ -15,7 +15,11 @@
 #endif
 
 #if !SERIALIZATION4
-#define SERIALIZATION4
+//#define SERIALIZATION4
+#endif
+
+#if !SERIALIZATION5
+#define SERIALIZATION5
 #endif
 
 namespace HelloWorld;
@@ -51,6 +55,10 @@ internal static class Program
 
 #if SERIALIZATION4
         Serialization4.Run();
+#endif
+
+#if SERIALIZATION5
+        Serialization5.Run();
 #endif
     }
 }

--- a/IronPythonIntro/HelloWorld/Program.cs
+++ b/IronPythonIntro/HelloWorld/Program.cs
@@ -8,7 +8,7 @@
 
 namespace HelloWorld;
 
-internal class Program
+internal static class Program
 {
     static void Main(string[] args)
     {

--- a/IronPythonIntro/HelloWorld/PythonScripts/serialization1.py
+++ b/IronPythonIntro/HelloWorld/PythonScripts/serialization1.py
@@ -14,11 +14,11 @@ print("This is the type of students:")
 print(type(students))
 
 print("Writing students to file...")
-with open('student_info.txt', 'w') as data:
+with open(file="student_info.txt", mode="w", encoding="utf8") as data:
     data.write(str(students))
 
 print("Reading students to file...")
-with open("student_info.txt", 'r') as f:
+with open("student_info.txt", mode="r", encoding="utf8") as f:
     for students in f:
         print(students)
 

--- a/IronPythonIntro/HelloWorld/PythonScripts/serialization1.py
+++ b/IronPythonIntro/HelloWorld/PythonScripts/serialization1.py
@@ -1,4 +1,4 @@
-print('Starting a sample script')
+print("Starting a sample script")
 
 students = {
     "Student 1": {
@@ -10,17 +10,17 @@ students = {
     "Student 3": {"Name": "Elena", "Age": 14, "Grade": 8},
 }
 
-print('This is the type of students:')
+print("This is the type of students:")
 print(type(students))
 
-print('Writing students to file...')
+print("Writing students to file...")
 with open('student_info.txt', 'w') as data:
     data.write(str(students))
 
-print('Reading students to file...')
+print("Reading students to file...")
 with open("student_info.txt", 'r') as f:
     for students in f:
         print(students)
 
-print('This is the type of students after writing it to a text file:')
+print("This is the type of students after writing it to a text file:")
 print(type(students))

--- a/IronPythonIntro/HelloWorld/Serialization1.cs
+++ b/IronPythonIntro/HelloWorld/Serialization1.cs
@@ -1,0 +1,16 @@
+﻿namespace HelloWorld;
+
+internal class Serialization1
+{
+    public static void Run()
+    {
+        var basePath = Directory.GetParent(AppDomain.CurrentDomain.BaseDirectory);
+        var scriptFilePath = Path.Combine(basePath.FullName, "PythonScripts", "serialization1.py");
+
+        var scriptContent = File.ReadAllText(scriptFilePath, System.Text.Encoding.UTF8);
+
+        var eng = IronPython.Hosting.Python.CreateEngine();
+        var scope = eng.CreateScope();
+        eng.Execute(scriptContent, scope);
+    }
+}

--- a/IronPythonIntro/HelloWorld/Serialization1.cs
+++ b/IronPythonIntro/HelloWorld/Serialization1.cs
@@ -1,6 +1,6 @@
 ﻿namespace HelloWorld;
 
-internal class Serialization1
+internal static class Serialization1
 {
     public static void Run()
     {

--- a/IronPythonIntro/HelloWorld/Serialization2.cs
+++ b/IronPythonIntro/HelloWorld/Serialization2.cs
@@ -1,0 +1,16 @@
+﻿namespace HelloWorld;
+
+internal static class Serialization2
+{
+    public static void Run()
+    {
+        var basePath = Directory.GetParent(AppDomain.CurrentDomain.BaseDirectory);
+        var scriptFilePath = Path.Combine(basePath.FullName, "PythonScripts", "serialization2.py");
+
+        var scriptContent = File.ReadAllText(scriptFilePath, System.Text.Encoding.UTF8);
+
+        var eng = IronPython.Hosting.Python.CreateEngine();
+        var scope = eng.CreateScope();
+        eng.Execute(scriptContent, scope);
+    }
+}

--- a/IronPythonIntro/HelloWorld/Serialization3.cs
+++ b/IronPythonIntro/HelloWorld/Serialization3.cs
@@ -1,0 +1,16 @@
+﻿namespace HelloWorld;
+
+internal static class Serialization3
+{
+    public static void Run()
+    {
+        var basePath = Directory.GetParent(AppDomain.CurrentDomain.BaseDirectory);
+        var scriptFilePath = Path.Combine(basePath.FullName, "PythonScripts", "serialization3.py");
+
+        var scriptContent = File.ReadAllText(scriptFilePath, System.Text.Encoding.UTF8);
+
+        var eng = IronPython.Hosting.Python.CreateEngine();
+        var scope = eng.CreateScope();
+        eng.Execute(scriptContent, scope);
+    }
+}

--- a/IronPythonIntro/HelloWorld/Serialization4.cs
+++ b/IronPythonIntro/HelloWorld/Serialization4.cs
@@ -1,0 +1,16 @@
+﻿namespace HelloWorld;
+
+internal static class Serialization4
+{
+    public static void Run()
+    {
+        var basePath = Directory.GetParent(AppDomain.CurrentDomain.BaseDirectory);
+        var scriptFilePath = Path.Combine(basePath.FullName, "PythonScripts", "serialization4.py");
+
+        var scriptContent = File.ReadAllText(scriptFilePath, System.Text.Encoding.UTF8);
+
+        var eng = IronPython.Hosting.Python.CreateEngine();
+        var scope = eng.CreateScope();
+        eng.Execute(scriptContent, scope);
+    }
+}

--- a/IronPythonIntro/HelloWorld/Serialization5.cs
+++ b/IronPythonIntro/HelloWorld/Serialization5.cs
@@ -1,0 +1,16 @@
+﻿namespace HelloWorld;
+
+internal static class Serialization5
+{
+    public static void Run()
+    {
+        var basePath = Directory.GetParent(AppDomain.CurrentDomain.BaseDirectory);
+        var scriptFilePath = Path.Combine(basePath.FullName, "PythonScripts", "serialization5.py");
+
+        var scriptContent = File.ReadAllText(scriptFilePath, System.Text.Encoding.UTF8);
+
+        var eng = IronPython.Hosting.Python.CreateEngine();
+        var scope = eng.CreateScope();
+        eng.Execute(scriptContent, scope);
+    }
+}

--- a/IronPythonIntro/HelloWorld/Serialization6.cs
+++ b/IronPythonIntro/HelloWorld/Serialization6.cs
@@ -1,0 +1,16 @@
+﻿namespace HelloWorld;
+
+internal static class Serialization6
+{
+    public static void Run()
+    {
+        var basePath = Directory.GetParent(AppDomain.CurrentDomain.BaseDirectory);
+        var scriptFilePath = Path.Combine(basePath.FullName, "PythonScripts", "serialization6.py");
+
+        var scriptContent = File.ReadAllText(scriptFilePath, System.Text.Encoding.UTF8);
+
+        var eng = IronPython.Hosting.Python.CreateEngine();
+        var scope = eng.CreateScope();
+        eng.Execute(scriptContent, scope);
+    }
+}


### PR DESCRIPTION
In this PR, I tried to go full with examples from Pickle tutorial and execute them using IronPython. Some of examples didn't work out due to lack of support to NumPy, Pandas and SciKitLearn packages.

Commits and their details

1. **e0af3c2** build(dotnet): Changed ItemGroup element to copy all scripts under PythonScripts folder when building

1. **056678d** refactor(style): Replaced single quotes with double quotes
    Formatting performed by Visual Studio Community 2022

1. **6e3e92b** refactor(style): Added named parameter to open function calls

1. **cdf90cf** feat(dotnet): Added conditional compilation variables to play with IronPython and Pickling

1. **dbf40c4** feat: New class to call serialization1.py script using IronPython

    created file IronPythonIntro/HelloWorld/Serialization1.cs

1. **f8d0ebe** build(dotnet): New reference to standard libs of IronPython / CPython

   - This library was essential to get rid of strange errors in calling serialization1.py
       - https://stackoverflow.com/a/67905932

   - Some links consulted before realizing the working solution:
       - https://stackoverflow.com/questions/55738377/python3-forcing-utf-8-for-stdout-stderr-without-externally-setting-pythonioenco?rq=3
       - https://peps.python.org/pep-0263/
       - https://stackoverflow.com/questions/37177394/ironpython-2-7-accented-characters-syntaxerrorexception
       - https://bobbyhadz.com/blog/python-lookuperror-unknown-encoding
       - https://discourse.pyrevitlabs.io/t/ironpython3-4-version-error-cp949-unknown-encoding-error/1826
       - https://stackoverflow.com/questions/588792/ironpython-lookuperror-unknown-encoding-hex
       - https://stackoverflow.com/questions/61644658/lookuperror-unknown-encoding-cp65001-even-with-pythonioencoding-utf-8
       - https://stackoverflow.com/questions/16549332/python-3-how-to-specify-stdin-encoding

1. **bf12d3f** chore(settings): New scope of conventional commits

1. **547bf37** refactor: Added static qualifier to Program and Serialization1 classes following analyzer advice

1. **7c88935** feat: Added wrapper code for IronPython that calls serialization2.py

    created file IronPythonIntro/HelloWorld/Serialization2.cs
1. **877be68** feat: Added wrapper code for IronPython that calls serialization3.py

   - Not working due to lack of compatibility with Numpy
       created file IronPythonIntro/HelloWorld/Serialization3.cs

1. **fb65d2b** feat: Added wrapper code for IronPython that calls serialization4.py

   - Not working due to lack of compatibility with Numpy and pandas
       created file IronPythonIntro/HelloWorld/Serialization4.cs

1. **7632a79** feat: Added wrapper code for IronPython that calls serialization5.py
    created file IronPythonIntro/HelloWorld/Serialization5.cs

1. **f25b946** feat: Added wrapper code for IronPython that calls serialization6.py

   - Not working due to lack of compatibility with scikit
       created file IronPythonIntro/HelloWorld/Serialization6.cs
